### PR TITLE
axiosのtimeoutの秒数の延長、ページネーションの表示データ数の縮小

### DIFF
--- a/apiv1/paginations.py
+++ b/apiv1/paginations.py
@@ -2,7 +2,7 @@ from rest_framework import pagination, response
 
 
 class CustomPagination(pagination.PageNumberPagination):
-    page_size = 9
+    page_size = 6
 
     def get_paginated_response(self, data):
         return response.Response({

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3,7 +3,7 @@ import store from './store';
 
 const api = axios.create({
 	baseURL: process.env.VUE_APP_API_BASE_URL,
-	timeout: 15000,
+	timeout: 30000,
 	headers: {
 		'Content-Type': 'application/json',
 		'X-Requested-With': 'XMLHttpRequest'
@@ -62,7 +62,7 @@ api.interceptors.response.use(
 
 const publicApi = axios.create({ // リクエスト時にトークンの検証を行わない。
 	baseURL: process.env.VUE_APP_API_BASE_URL,
-	timeout: 10000,
+	timeout: 30000,
 	headers: {
 		'Content-Type': 'application/json',
 		'X-Requested-With': 'XMLHttpRequest'


### PR DESCRIPTION
axiosのtimeoutの延長

- 20秒から30秒に延長。

ページネーションの表示データ数の縮小

- 表示データ数を９から６に変更。
