### PR TITLE
ページネーションと画像圧縮機能の設定を変更

### DIFF
--- a/apiv1/paginations.py
+++ b/apiv1/paginations.py
@@ -2,7 +2,7 @@ from rest_framework import pagination, response
 
 
 class CustomPagination(pagination.PageNumberPagination):
-    page_size = 6
+    page_size = 3
 
     def get_paginated_response(self, data):
         return response.Response({

--- a/frontend/src/components/PostImageForm.vue
+++ b/frontend/src/components/PostImageForm.vue
@@ -54,7 +54,7 @@ export default {
       // 投稿画像を圧縮
       new Compressor(data, {
         // 圧縮した画像の解像度
-        quality: 0.6,
+        quality: 0.5,
         // 圧縮成功時の処理
         success(result) {
           _this


### PR DESCRIPTION
ページネーション

- １ページでの投稿表示数を６から３に変更

画像圧縮機能

- 画像圧縮ライブラリcompressor.jsを使って作成したCompressorインスタンスのquality属性の値を0.6から0.5に変更し画質を落とした。