### PR TITLE
投稿編集画面で非公開の投稿を削除できないバグの修正

### DIFF
--- a/frontend/src/views/EditPostPage.vue
+++ b/frontend/src/views/EditPostPage.vue
@@ -205,7 +205,7 @@ export default {
     deletePost() {
       this.disabled = true;
       api
-        .delete("/posts/" + this.id + "/")
+        .delete("/users_post/" + this.id + "/")
         .then(() => {
           this.$router.replace("/");
         })


### PR DESCRIPTION
削除する際にリクエストを送るDjangoのAPIのurlを以下のように変更した。

-  修正前  /posts/  
-  修正後  /users_post/