### PR TITLE
投稿編集画面で削除と入力してEnterを押したときに削除ボタンではなく投稿編集ボタンのメソッドが発火されるバグを修正

### DIFF
--- a/frontend/src/views/EditPostPage.vue
+++ b/frontend/src/views/EditPostPage.vue
@@ -7,6 +7,7 @@
         <form
           id="edit-form"
           @submit.prevent
+          @keydown.enter.prevent
           class="box column is-5-desktop is-6-tablet is-8-mobile"
         >
           <div id="form-container">


### PR DESCRIPTION
投稿編集画面にてEnterを押すイベントで発生するデフォルトの挙動を制御することで解決した。