### PR TITLE
apiへリクエストを送る際のクエリパラメータの指定方法の変更

### DIFF
--- a/frontend/src/components/CategoryFilter.vue
+++ b/frontend/src/components/CategoryFilter.vue
@@ -220,12 +220,16 @@ export default {
     },
     clickSearchButton() {
       let query = "";
+      // djangoのFilterクラスのカテゴリーの指定方法の都合上
+      // カテゴリーのクエリパラメータは文字列で指定する。
       const firstCategory = this.selectedCategoryList[0];
-      for (const category of this.selectedCategoryList) {
-        if (category === firstCategory) {
-          query += "?categorys=" + category;
-        } else {
-          query += "&categorys=" + category;
+      if (this.selectedCategoryList.length) {
+        for (const category of this.selectedCategoryList) {
+          if (category === firstCategory) {
+            query += "?categorys=" + category;
+          } else {
+            query += "&categorys=" + category;
+          }
         }
       }
       if (this.selectedPrefecture) {

--- a/frontend/src/components/MyProfile.vue
+++ b/frontend/src/components/MyProfile.vue
@@ -59,12 +59,14 @@ export default {
     api.get("/users_post/").then((response) => {
       this.myPostsCount = response.data.count;
     });
-    api.get("/following/?followers=True").then((followingObjects) => {
-      followingObjects.data.forEach((following) => {
-        this.myFollowers.push(following.followed_by);
-        this.numberOfFollowers = followingObjects.data.length;
+    api
+      .get("/following/", { params: { followers: "True" } })
+      .then((followingObjects) => {
+        followingObjects.data.forEach((following) => {
+          this.myFollowers.push(following.followed_by);
+          this.numberOfFollowers = followingObjects.data.length;
+        });
       });
-    });
   },
   computed: {
     ...mapGetters("auth", ["favoriteUsersList"]),
@@ -80,7 +82,8 @@ export default {
       this.$emit("showFollowers", this.myFollowers);
     },
     showMyFavoriteUsers() {
-      this.$emit("showFavoriteUsers"); // mypageでのViewFavoriteUserはvuexから値を得るためここからデータを送らなくていい。
+      // mypageでのViewFavoriteUserはvuexから値を得るためここからデータを送らなくていい。
+      this.$emit("showFavoriteUsers");
     },
     moveTab(tabIndex) {
       this.$emit("moveTabInMyPage", tabIndex);

--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -197,6 +197,8 @@ export default {
         // viewsetのパーミッション: IsAuthenticatedOrReadOnly
         axios = publicApi;
       }
+      // djangoのFilterクラスのカテゴリーの指定方法の都合上
+      // クエリパラメータは文字列で指定する。
       let true_url = url;
       if (this.searchKeyword) {
         const keywordQuery =

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -120,7 +120,7 @@ export default {
     },
     clickForSearch() {
       publicApi
-        .get("/posts/?keyword=" + this.searchKeyword)
+        .get("/posts/", { params: { keyword: this.searchKeyword } })
         .then((response) => {
           this.posts = response.data.results;
           if (this.posts.length) {

--- a/frontend/src/views/ViewUserPage.vue
+++ b/frontend/src/views/ViewUserPage.vue
@@ -119,7 +119,9 @@ export default {
             this.favoriteUsersCount = followingObjects.data.length;
           });
         publicApi
-          .get("/following/?followers=True&user=" + this.user.id)
+          .get("/following/", {
+            params: { followers: "True", user: this.user.id },
+          })
           .then((followingObjects) => {
             // userのフォロワーを取得
             followingObjects.data.forEach((following) => {


### PR DESCRIPTION
**修正前**

axios.get('/url/?param=a')<br><br>

**修正後**

axios.get('/url/', { params: { param: 'a' } })<br><br>

クエリパラメータにカテゴリーを含めるときはdjango側の都合上クエリを文字列で指定しなければならないので、その部分は修正対象から外した。