### PR TITLE
CustomUserViewSetからお気に入りの投稿の追加・削除機能を削除した。

### DIFF
--- a/apiv1/views.py
+++ b/apiv1/views.py
@@ -88,7 +88,6 @@ class MyPostViewSet(viewsets.ModelViewSet):
 
 
 class CustomUserViewSet(mixins.RetrieveModelMixin,
-                        mixins.UpdateModelMixin,
                         viewsets.GenericViewSet):
     """
     自分以外のユーザー情報取得（個別）・更新View

--- a/frontend/src/views/ViewPostPage.vue
+++ b/frontend/src/views/ViewPostPage.vue
@@ -195,10 +195,11 @@ export default {
         ].slice(); // リストをコピー
         favoritePostsIdList.push(this.id); // コピーしたリストに追加
         api
-          .patch(
-            "/custom_users/" + this.$store.getters["auth/username"] + "/",
-            { favorite_posts: favoritePostsIdList }
-          )
+          // .patch(
+          //   "/custom_users/" + this.$store.getters["auth/username"] + "/",
+          //   { favorite_posts: favoritePostsIdList }
+          // )
+          .patch("/auth/users/me/", { favorite_posts: favoritePostsIdList })
           .then(() => {
             this.$store.dispatch(
               "auth/setFavoritePostsIdList",
@@ -215,7 +216,7 @@ export default {
         (id) => id !== this.id
       );
       api
-        .patch("/custom_users/" + this.$store.getters["auth/username"] + "/", {
+        .patch("/auth/users/me/", {
           favorite_posts: newFavoritePostsIdList,
         })
         .then(() => {


### PR DESCRIPTION
修正前

- ユーザーのお気に入りの投稿の追加・削除をCustomUserViewSetで行っていた。<br><br>


修正後

- お気に入りの投稿の追加・削除のリクエストのエンドポイントをDjoserへ変更した。