### PR TITLE
FollowingViewSetのpostメソッドとdeleteメソッドの機能にパーミッションを追加

### DIFF
--- a/apiv1/permissions.py
+++ b/apiv1/permissions.py
@@ -14,3 +14,16 @@ class MyFavoritePostsPermission(BasePermission):
     def has_object_permission(self, request, view, obj):
         favorite_posts_list = request.user.favorite_posts.all()
         return obj in favorite_posts_list or request.user.is_superuser
+
+
+class MyFollowingDataPermission(BasePermission):
+    """
+    Followingモデルのデータの追加・削除に対するパーミッションクラス
+
+    followed_byフィールドのユーザーとログインユーザーが同じかどうか判定
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in ['POST', 'DELETE']:
+            return obj.followed_by == request.user or request.user.is_superuser
+        return True

--- a/apiv1/views.py
+++ b/apiv1/views.py
@@ -20,18 +20,19 @@ from .serializers import (
 from .paginations import CustomPagination
 from .filters import PostFilter
 from .permissions import (
-    UsersPostPermission, MyFavoritePostsPermission
+    UsersPostPermission, MyFavoritePostsPermission,
+    MyFollowingDataPermission,
 )
 
 
-class PublicPostViewSet(mixins.RetrieveModelMixin, 
-                        mixins.ListModelMixin, 
+class PublicPostViewSet(mixins.RetrieveModelMixin,
+                        mixins.ListModelMixin,
                         viewsets.GenericViewSet):
     """
     公開されている投稿取得（一覧・個別）View
 
     自分の投稿は扱わない
-    
+
     URL: /posts/
 
     以下アクセス元
@@ -109,7 +110,7 @@ class CustomUserViewSet(mixins.RetrieveModelMixin,
 class FavoritePostsListView(generics.ListAPIView):
     """
     お気に入りの投稿一覧取得APIクラス
-    
+
     URL: /favorite_posts/
 
     以下アクセス元
@@ -136,7 +137,7 @@ class FollowingViewSet(mixins.CreateModelMixin,
                        viewsets.GenericViewSet):
     """
     自分のフォロワー・フォローユーザーの情報取得（一覧）・作成・削除ViewSet
-    
+
     URL: /following/
 
     以下アクセス元
@@ -147,7 +148,9 @@ class FollowingViewSet(mixins.CreateModelMixin,
     """
 
     serializer_class = FollowingSerializer
-    permission_classes = [IsAuthenticatedOrReadOnly]
+    permission_classes = [
+        IsAuthenticatedOrReadOnly, MyFollowingDataPermission
+    ]
 
     def get_queryset(self):
         # ユーザーのフォロワー取得


### PR DESCRIPTION
修正前

- FollowingViewSetでのFollowingモデルのオブジェクト作成・削除の処理は認証さえしていれば誰でも可能だった。

修正後

- Followingモデルのオブジェクト作成・削除の処理はfollowed_byフィールドとログインユーザーが同じ場合のみ許可するようにした。