### PR TITLE
画像選択ボタンの文字が見切れるのを修正

### DIFF
--- a/frontend/src/components/PostImageForm.vue
+++ b/frontend/src/components/PostImageForm.vue
@@ -12,11 +12,11 @@
           name="resume"
           @change="onImageChange"
         />
-        <span class="file-cta">
+        <span class="file-cta image-button">
           <span class="file-icon">
             <fa-icon icon="file-upload"></fa-icon>
           </span>
-          <span class="file-label"> 画像を選択 </span>
+          <span class="file-label select-image"> 画像を選択 </span>
         </span>
         <span class="file-name">{{ this.fileName }}</span>
       </label>
@@ -66,13 +66,11 @@ export default {
         quality: 0.5,
         // 圧縮成功時の処理
         success(result) {
-          _this
-            .getFileData(result)
-            .then((fileData) => {
-              _this.previewSrc = fileData;
-              // 指定画像の変化があれば新しい画像のファイルを親コンポーネントへ渡す
-              _this.$emit("changeImage", _this.picture, _this.fileName);
-            });
+          _this.getFileData(result).then((fileData) => {
+            _this.previewSrc = fileData;
+            // 指定画像の変化があれば新しい画像のファイルを親コンポーネントへ渡す
+            _this.$emit("changeImage", _this.picture, _this.fileName);
+          });
         },
         maxWidth: 400,
         maxHeight: 400,
@@ -108,5 +106,17 @@ export default {
   max-width: 100%;
   height: auto;
   margin: 0 auto;
+}
+@media screen and (max-width: 768px) {
+  .select-image {
+    display: none;
+  }
+  .image-button {
+    width: 15%;
+  }
+  .image-button > span {
+    margin: 0;
+    width: 100%;
+  }
 }
 </style>

--- a/frontend/src/views/EditProfilePage.vue
+++ b/frontend/src/views/EditProfilePage.vue
@@ -27,7 +27,7 @@
                   <span class="file-icon">
                     <fa-icon icon="file-upload"></fa-icon>
                   </span>
-                  <span class="file-label"> 画像を選択 </span>
+                  <span id="select-icon" class="file-label"> 画像 </span>
                 </span>
                 <span class="file-name">{{ this.iconFileName }}</span>
               </label>
@@ -139,11 +139,9 @@ export default {
         quality: 0.6,
         // 圧縮成功時の処理
         success(result) {
-          _this
-            .getFileData(result)
-            .then((fileData) => {
-              _this.newIconSrc = fileData;
-            });
+          _this.getFileData(result).then((fileData) => {
+            _this.newIconSrc = fileData;
+          });
         },
         maxWidth: 200,
         maxHeight: 200,
@@ -190,7 +188,7 @@ export default {
 
 <style scoped>
 #image-select {
-  width: 30%;
+  width: 25%;
 }
 .form-container {
   margin: 0 auto;
@@ -218,5 +216,16 @@ button {
   height: 100px;
   object-fit: cover;
   border-radius: 50%;
+}
+@media screen and (max-width: 768px) {
+  #select-icon {
+    display: none;
+  }
+  #image-select {
+    width: 10%;
+  }
+  #image-select > span {
+    width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
投稿画面、投稿編集画面、プロフィール編集画面の画像選択ボタンの「画像を選択」という文字が見切れてしまうので、スマートフォンサイズの画面では文字を表示しないようにした。