### PR TITLE
CustomUserSerializerとPostSerializerでPostモデルのpictureとCustomUserモデルのiconをwrite_onlyに設定

### DIFF
--- a/apiv1/serializers.py
+++ b/apiv1/serializers.py
@@ -23,6 +23,11 @@ class CustomUserSerializer(serializers.ModelSerializer):
             'favorite_posts', 'icon', 'icon_url', 'icon_filename', 
             'registered_date',
         ]
+        extra_kwargs = {
+            'icon': {
+                'write_only': True,
+            }
+        }
 
 
 class PostSerializer(serializers.ModelSerializer):
@@ -54,6 +59,11 @@ class PostSerializer(serializers.ModelSerializer):
             'author', 'status', 'category', 'zip_code', 
             'prefecture', 'location'
         ]
+        extra_kwargs = {
+            'picture': {
+                'write_only': True,
+            }
+        }
 
 
 class FollowingSerializer(serializers.ModelSerializer):

--- a/frontend/src/views/EditPostPage.vue
+++ b/frontend/src/views/EditPostPage.vue
@@ -179,7 +179,6 @@ export default {
       // 元の投稿データから画像関連の属性を削除
       delete this.post.picture_url;
       delete this.post.picture_filename;
-      delete this.post.picture;
       Object.entries(this.post).forEach(([key, value]) => {
         if (key === "category") {
           value.forEach((value) => {


### PR DESCRIPTION
レスポンスとして返されてはいたがフロントエンドで使われていなかったpictureフィールドとiconフィールドを各シリアライザでwrite_onlyに設定しなおした。