### PR TITLE
【store/modules/pagination.js】Vuexのpagination.jsで投稿のリストの状態を管理できるようにした

### DIFF
--- a/frontend/src/components/CategoryFilter.vue
+++ b/frontend/src/components/CategoryFilter.vue
@@ -255,6 +255,7 @@ export default {
       // フィルタリング
       publicApi.get("/posts/" + query).then((response) => {
         this.$emit("searchForCategory", response.data.results);
+        // ページネーションの状態を更新
         this.$store.dispatch("pagination/setPagination", response.data);
         this.$store.dispatch(
           "pagination/registerSearchCategorys",

--- a/frontend/src/components/MyPosts.vue
+++ b/frontend/src/components/MyPosts.vue
@@ -1,18 +1,16 @@
 <template>
-  <div v-if="myPosts.length">
+  <div v-if="count">
     <!-- 投稿一覧 -->
-    <PostsList :posts="myPosts"></PostsList>
+    <PostsList :posts="results"></PostsList>
 
     <!-- ページネーション -->
-    <Pagination @paginate="setMyPosts($event)" class="mt-5"></Pagination>
+    <Pagination class="mt-5"></Pagination>
   </div>
-  <div v-else>
-    {{ noPosts }}
-  </div>
+  <div v-else>投稿がありません。</div>
 </template>
 
 <script>
-import api from "@/api";
+import { mapGetters } from "vuex";
 import Pagination from "@/components/Pagination";
 import PostsList from "@/components/PostsList";
 
@@ -21,28 +19,9 @@ export default {
     Pagination,
     PostsList,
   },
-  data() {
-    return {
-      myPosts: [],
-      noPosts: "",
-    };
-  },
-  mounted() {
-    // ログインユーザーの投稿を取得
-    api.get("/users_post/").then((response) => {
-      if (response.data.results.length) {
-        this.myPosts = response.data.results;
-        this.$store.dispatch("pagination/setPagination", response.data);
-      } else {
-        this.noPosts = "投稿はありません。";
-      }
-    });
-  },
-  methods: {
-    // ページ移動した際にPaginationコンポーネントから投稿の配列を取得
-    setMyPosts(posts) {
-      this.myPosts = posts;
-    },
+  computed: {
+    // 投稿数と投稿リスト
+    ...mapGetters("pagination", ["count", "results"]),
   },
 };
 </script>

--- a/frontend/src/components/MyProfile.vue
+++ b/frontend/src/components/MyProfile.vue
@@ -5,7 +5,7 @@
         <!-- 投稿数 -->
         <div class="tile is-parent">
           <article class="tile is-child box click-cursor" @click="moveTab(1)">
-            <p class="title">{{ myPostsCount }}</p>
+            <p class="title">{{ count }}</p>
             <p class="subtitle">投稿数</p>
           </article>
         </div>
@@ -60,15 +60,10 @@ export default {
   data() {
     return {
       numberOfFollowers: 0,
-      myPostsCount: 0,
       myFollowers: [],
     };
   },
   mounted() {
-    // 投稿数を保存
-    api.get("/users_post/").then((response) => {
-      this.myPostsCount = response.data.count;
-    });
     // ログインユーザーのフォロワー取得
     api
       .get("/following/", { params: { followers: "True" } })
@@ -82,7 +77,9 @@ export default {
       });
   },
   computed: {
+    // フォローしているユーザーのリスト
     ...mapGetters("auth", ["favoriteUsersList"]),
+    ...mapGetters("pagination", ["count"]), // 投稿数
     numberOfFavoritePosts() {
       if (this.user.favorite_posts) {
         return this.user.favorite_posts.length;

--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -4,7 +4,7 @@
       <ul class="pagination-list">
         <nav class="pagination" role="navigation" aria-label="pagination">
           <ul class="pagination-list">
-            <!-- 全ページ数が10以下の場合 -->
+            <!-- 前ページへの移動ボタン -->
             <li>
               <a
                 class="pagination-previous"
@@ -19,6 +19,8 @@
                 >前のページ</a
               >
             </li>
+
+            <!-- 全ページ数が10以下の場合 -->
             <template v-if="totalPages <= 10">
               <li v-for="pageNum in totalPages" :key="pageNum">
                 <a
@@ -29,6 +31,7 @@
                 >
               </li>
             </template>
+
             <!-- 全ページ数が10以上ある場合 -->
             <template v-else>
               <!-- 現在のページ番号が10以下の場合 -->
@@ -43,6 +46,7 @@
                   </a>
                 </li>
               </template>
+
               <!-- 現在のページ番号が10より上の場合 -->
               <template v-else>
                 <!-- 現在のページの十の位が総ページ数の十の位と等しいとき -->
@@ -62,6 +66,7 @@
                       </a>
                     </li>
                   </template>
+
                   <!-- 上記の条件に加えて現在のページ番号の一の位が0出ないとき（11、21など） -->
                   <template v-else>
                     <li v-for="pageNum in divisionRemainder" :key="pageNum">
@@ -75,6 +80,7 @@
                     </li>
                   </template>
                 </template>
+
                 <!-- 現在のページの十の位が総ページ数の十の位と等しくないとき -->
                 <template v-else>
                   <li v-for="pageNum in 10" :key="pageNum">
@@ -89,6 +95,8 @@
                 </template>
               </template>
             </template>
+
+            <!-- 次ページへの移動ボタン -->
             <li>
               <a
                 class="pagination-next"
@@ -104,6 +112,8 @@
         </nav>
       </ul>
     </nav>
+
+    <!-- タブレット用ボタン -->
     <div class="text-align-center desktop-none">
       <div>
         <a class="pagination-link is-current">{{ currentPage }}</a>
@@ -165,6 +175,7 @@ export default {
       "searchPrefecture",
     ]),
     totalPagesDivideTen() {
+      // 前ページ数を10で割った値
       return Math.floor(this.totalPages / 10);
     },
     divisionRemainder() {
@@ -183,7 +194,10 @@ export default {
   methods: {
     movePage(pageNumber) {
       let url = "";
+
+      // ページによって使用するaxiosのインスタンスが違う
       let axios = {};
+
       if (this.$route.name === "myPosts") {
         url = "/users_post/";
         // viewsetのパーミッション: IsAuthenticated
@@ -197,8 +211,10 @@ export default {
         // viewsetのパーミッション: IsAuthenticatedOrReadOnly
         axios = publicApi;
       }
+
       // djangoのFilterクラスのカテゴリーの指定方法の都合上
-      // クエリパラメータは文字列で指定する。
+      // クエリパラメータは文字列で指定する
+      // query: {} 形式ではない
       let true_url = url;
       if (this.searchKeyword) {
         const keywordQuery =
@@ -228,10 +244,11 @@ export default {
       }
       axios.get(true_url).then((response) => {
         this.$emit("paginate", response.data.results);
+        // vuexのページネーションの状態を更新
         this.$store
           .dispatch("pagination/setPagination", response.data)
           .then(() => {
-            // vuexのpaginationの情報が設定され終わったら（DOMへ反映されたら）is-currentを付与する。
+            // vuexのpaginationの情報が設定され終わったら（DOMへ反映されたら）is-currentを付与する
             document.getElementById(pageNumber).classList.add("is-current");
           });
       });
@@ -239,7 +256,7 @@ export default {
   },
   watch: {
     currentPage(newPage, oldPage) {
-      // 現在のページの値が更新されるとis-currentを新しいページの要素に付け替える。
+      // 現在のページの値が更新されるとis-currentを新しいページの要素に付け替える
       // is-currentを要素から除去。
       if (oldPage) {
         document.getElementById(oldPage).classList.remove("is-current");

--- a/frontend/src/store/modules/pagination.js
+++ b/frontend/src/store/modules/pagination.js
@@ -1,13 +1,14 @@
 const state = {
 	next: '',
 	previous: '',
-	count: 0,
+	count: 0, // 全投稿数
 	totalPages: 0,
 	currentPage: 0,
 	pageSize: 0,
-	searchKeyword: '',
-	searchCategorys: [],
-	searchPrefecture: ''
+	results: [], // 取得した投稿リスト
+	searchKeyword: '', // 検索キーワード
+	searchCategorys: [], // カテゴリフィルタのリスト
+	searchPrefecture: '', // 都道府県フィルタの値
 };
 
 const getters = {
@@ -19,8 +20,9 @@ const getters = {
 	previousPage: state => state.currentPage - 1,
 	nextPage: state => state.currentPage + 1,
 	pageSize: state => state.pageSize,
-	hasNext: state => !!state.next,
-	hasPrevious: state => !!state.previous,
+	results: state => state.results, // 投稿リストを参照
+	hasNext: state => !!state.next, // 次のページがあるかどうか
+	hasPrevious: state => !!state.previous, // 前のページがあるかどうか
 	searchKeyword: state => state.searchKeyword,
 	searchCategorys: state => state.searchCategorys,
 	searchPrefecture: state => state.searchPrefecture
@@ -34,8 +36,9 @@ const mutations = {
 		state.totalPages = payload.total_pages;
 		state.currentPage = payload.current_page;
 		state.pageSize = payload.page_size;
+		state.results = payload.results; // 投稿リストを保存
 	},
-	setSearchKeyword(state, payload) { // こっちもクリアしないと値が残るかも
+	setSearchKeyword(state, payload) {
 		state.searchKeyword = payload.searchKeyword;
 	},
 	setSearchCategorys(state, payload) {

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -39,7 +39,7 @@
       </div>
 
       <!-- 投稿が存在する場合 -->
-      <div v-if="posts.length">
+      <div v-if="count">
         <!-- フィルタ -->
         <div class="pb-5">
           <!-- フィルタ表示切り替えボタン -->
@@ -55,7 +55,6 @@
           <CategoryFilter
             id="tablet-category-filter"
             class="p-4"
-            @searchForCategory="setPostsInHome($event)"
             v-show="filtering"
           ></CategoryFilter>
         </div>
@@ -63,16 +62,12 @@
         <div class="columns posts-container is-marginless">
           <!-- 投稿表示部分 -->
           <div class="column">
-            <PostsList :posts="posts"></PostsList>
-            <Pagination
-              @paginate="setPostsInHome($event)"
-              class="mt-6"
-            ></Pagination>
+            <PostsList :posts="results"></PostsList>
+            <Pagination class="mt-6"></Pagination>
           </div>
           <!-- フィルタ部分（デスクトップ用） -->
           <CategoryFilter
             id="pc-category-filter"
-            @searchForCategory="setPostsInHome($event)"
             class="column is-3 ml-5"
             v-show="filtering"
           ></CategoryFilter>
@@ -89,6 +84,7 @@
 
 <script>
 import { publicApi } from "@/api";
+import { mapGetters } from "vuex";
 import GlobalMenu from "@/components/GlobalMenu";
 import Pagination from "@/components/Pagination";
 import CategoryFilter from "@/components/CategoryFilter";
@@ -106,7 +102,6 @@ export default {
   props: ["before"],
   data() {
     return {
-      posts: [],
       searchKeyword: "",
       filtering: false,
       noPosts: "",
@@ -115,11 +110,13 @@ export default {
       },
     };
   },
+  computed: {
+    ...mapGetters("pagination", ["results", "count"]),
+  },
   mounted() {
     publicApi.get("/posts/").then((response) => {
       // 投稿が存在するとき
       if (response.data.results.length) {
-        this.posts = response.data.results;
         this.$store.dispatch("pagination/setPagination", response.data);
       } else {
         // 投稿が空のとき
@@ -131,16 +128,6 @@ export default {
     // 投稿詳細画面へ
     viewPost(postId) {
       this.$router.push({ name: "viewPost", params: { id: postId } });
-    },
-    setPostsInHome(postsData) {
-      // 保存済みのpostsを初期化
-      // vuexのページネーションの設定はCategoryFilterで行っている
-      this.posts = [];
-      if (postsData.length) {
-        this.posts = postsData;
-      } else {
-        this.noPosts = "投稿が見つかりませんでした。";
-      }
     },
     // キーワード検索
     clickForSearch() {

--- a/frontend/src/views/MyPage.vue
+++ b/frontend/src/views/MyPage.vue
@@ -127,9 +127,18 @@ export default {
     const searchRouteIndex = this.routeName.indexOf(this.$route.name);
     // URLに応じてisActiveの値を変える
     this.isActive = searchRouteIndex;
+
     // ログインユーザーの情報を取得
     api.get("/auth/users/me/").then((response) => {
       this.user = response.data;
+    });
+
+    // ログインユーザーの投稿を取得
+    // この時点でユーザーの投稿をvuexに保存し
+    // 子コンポーネントで投稿を参照するときはvuexから参照させる
+    api.get("/users_post/").then((response) => {
+      // ページネーションのデータを保存
+      this.$store.dispatch("pagination/setPagination", response.data);
     });
   },
   computed: {


### PR DESCRIPTION
#### 今までの投稿一覧データの管理

- ページのコンポーネントのdataとして保存していた。
- 投稿をフィルタリングや検索にかけたとき、その都度内容が変化した投稿のリストのデータをフィルタリングやページネーションのコンポーネントから$emitで送って親コンポーネントのdataに保存しなければならなかった。
- コンポーネントを切り替えるとデータが失われてしまったため、複数回APIへのリクエストを実行することがあった。<br><br>

#### 変更後の投稿一覧データの管理

- vuexで管理しているのでAPIへ余分なリクエストを送ったり、子コンポーネントで内容が変更された投稿一覧のデータを$emitで受け取ったりしなくていい。
- データの内容を変更した場合はすぐにvuexに変更が反映されるので、最新の投稿一覧のデータを取得したいときはvuexを参照すればいい。