### PR TITLE
【HomePage.vue】該当する投稿がなかったときのキーワード検索機能の処理を修正

### DIFF
--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -135,21 +135,20 @@ export default {
     },
     // キーワード検索
     clickForSearch() {
+      // 現在の検索キーワードをvuexに保存
+      this.$store.dispatch(
+        "pagination/registerSearchKeyword",
+        this.searchKeyword
+      );
+      
       publicApi
         .get("/posts/", { params: { keyword: this.searchKeyword } })
         .then((response) => {
-          this.posts = response.data.results;
-          // 投稿が存在する場合
-          if (this.posts.length) {
-            // レスポンスからvuexのページネーションの情報を更新
-            this.$store.dispatch("pagination/setPagination", response.data);
-            // 現在の検索キーワードをvuexに保存
-            this.$store.dispatch(
-              "pagination/registerSearchKeyword",
-              this.searchKeyword
-            );
-            // 投稿が存在しない場合
-          } else {
+          // レスポンスからvuexのページネーションの情報を更新
+          this.$store.dispatch("pagination/setPagination", response.data);
+
+          // 投稿が存在しない場合
+          if (!response.data.count) {
             this.noPosts = "投稿が見つかりませんでした。";
           }
         });


### PR DESCRIPTION
## Issue
#53 

## 内容
キーワード検索機能のメソッドで該当する投稿が見つかっても見つからなくても、pagination.jsのVuexの状態を更新するようにコードを修正