### PR TITLE
【MyPage.vue, HomePage.vue, ViewUserPage.vue】ページ移動時にVuexの投稿リストを初期化する処理を修正

### DIFF
--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -140,7 +140,7 @@ export default {
         "pagination/registerSearchKeyword",
         this.searchKeyword
       );
-      
+
       publicApi
         .get("/posts/", { params: { keyword: this.searchKeyword } })
         .then((response) => {
@@ -187,14 +187,6 @@ export default {
       next();
     }
   },
-  destroyed() {
-    // vuexの検索ワードの値を初期化
-    this.$store.dispatch("pagination/destroySearchKeyword");
-    // paginationの情報を初期化
-    // この処理を行わないと別ページで投稿リストを表示するときに
-    // 数秒間古い投稿リストのデータが描画されてしまう
-    this.$store.dispatch("pagination/clearPagination");
-  },
   watch: {
     // フィルタから検索して該当する投稿がないとき
     // noPostsにメッセージを設定する
@@ -208,6 +200,23 @@ export default {
         this.noPosts = "投稿が見つかりませんでした。";
       }
     },
+  },
+  beforeRouteLeave(to, from, next) {
+    // vuexの検索ワードの値を初期化
+    this.$store.dispatch("pagination/destroySearchKeyword");
+
+    // paginationの情報を初期化
+    // この処理を行わないと別ページで投稿リストを表示するときに
+    // 数秒間古い投稿リストのデータが描画されてしまう
+    this.$store
+      .dispatch("pagination/clearPagination")
+      .then(() => {
+        // clearPaginationが完了してからページ遷移
+        next();
+      })
+      .catch(() => {
+        next();
+      });
   },
 };
 </script>

--- a/frontend/src/views/MyPage.vue
+++ b/frontend/src/views/MyPage.vue
@@ -158,11 +158,19 @@ export default {
       next();
     }
   },
-  destroyed() {
+  beforeRouteLeave(to, from, next) {
     // paginationの情報を初期化
     // この処理を行わないと別ページで投稿リストを表示するときに
     // 数秒間古い投稿リストのデータが描画されてしまう
-    this.$store.dispatch("pagination/clearPagination");
+    this.$store
+      .dispatch("pagination/clearPagination")
+      .then(() => {
+        // clearPaginationが完了してからページ遷移
+        next();
+      })
+      .catch(() => {
+        next();
+      });
   },
 };
 </script>

--- a/frontend/src/views/ViewUserPage.vue
+++ b/frontend/src/views/ViewUserPage.vue
@@ -234,11 +234,19 @@ export default {
       next();
     }
   },
-  destroyed() {
+  beforeRouteLeave(to, from, next) {
     // paginationの情報を初期化
     // この処理を行わないと別ページで投稿リストを表示するときに
     // 数秒間古い投稿リストのデータが描画されてしまう
-    this.$store.dispatch("pagination/clearPagination");
+    this.$store
+      .dispatch("pagination/clearPagination")
+      .then(() => {
+        // clearPaginationが完了してからページ遷移
+        next();
+      })
+      .catch(() => {
+        next();
+      });
   },
 };
 </script>


### PR DESCRIPTION
## Issue
#57 

## 内容
これまではページ退出時にdestroyedを使ってVuexに保存されている投稿リストのデータを初期化していたが、この状態では非公開の投稿がページ遷移時に数秒間表示されてしまうバグが発生するので、beforeRouteLeaveを使用して完全に投稿リストのデータの初期化が完了してからページ遷移するように変更
