### PR TITLE
【MyPage.vue, HomePage.vue, ViewUserPage.vue】ページ遷移時のVuexの投稿リストを初期化する処理を修正

### DIFF
--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -121,7 +121,7 @@ export default {
   mounted() {
     publicApi.get("/posts/").then((response) => {
       // vuexに投稿の情報を設定
-      this.$store.dispatch("pagination/setPagination", response.data);
+      this.$store.commit("pagination/set", response.data);
       // 投稿が空のとき
       if (!response.data.results.length) {
         this.noPosts = "投稿はありません。";

--- a/frontend/src/views/MyPage.vue
+++ b/frontend/src/views/MyPage.vue
@@ -133,7 +133,7 @@ export default {
     // 子コンポーネントで投稿を参照するときはvuexから参照させる
     api.get("/users_post/").then((response) => {
       // ページネーションのデータを保存
-      this.$store.dispatch("pagination/setPagination", response.data);
+      this.$store.commit("pagination/set", response.data);
     });
   },
   computed: {

--- a/frontend/src/views/ViewUserPage.vue
+++ b/frontend/src/views/ViewUserPage.vue
@@ -167,8 +167,8 @@ export default {
           .then((postResponse) => {
             if (postResponse.data.results.length) {
               // ページネーションの状態をセット
-              this.$store.dispatch(
-                "pagination/setPagination",
+              this.$store.commit(
+                "pagination/set",
                 postResponse.data
               );
             } else {


### PR DESCRIPTION
## Issue
#57 

## 内容
タイトルのページのmountedでのVuexに投稿リストのデータをセットする処理を非同期処理から同期処理へ変更