### PR TITLE
【MyPage.vue, HomePage.vue, ViewUserPage.vue】ページ遷移時のVuexの投稿リストを初期化する処理を修正

### DIFF
--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -205,10 +205,21 @@ export default {
     // vuexの検索ワードの値を初期化
     this.$store.dispatch("pagination/destroySearchKeyword");
 
+    // 初期化用データ
+    const clearData = {
+      next: "",
+      previous: "",
+      count: 0,
+      total_pages: 0,
+      current_page: 0,
+      page_size: 0,
+      results: [],
+    };
+
     // paginationの情報を初期化
     // この処理を行わないと別ページで投稿リストを表示するときに
     // 数秒間古い投稿リストのデータが描画されてしまう
-    this.$store.commit("pagination/clear");
+    this.$store.commit("pagination/set", clearData);
     next();
   },
 };

--- a/frontend/src/views/MyPage.vue
+++ b/frontend/src/views/MyPage.vue
@@ -159,10 +159,21 @@ export default {
     }
   },
   beforeRouteLeave(to, from, next) {
+    // 初期化用データ
+    const clearData = {
+      next: "",
+      previous: "",
+      count: 0,
+      total_pages: 0,
+      current_page: 0,
+      page_size: 0,
+      results: [],
+    };
+
     // paginationの情報を初期化
     // この処理を行わないと別ページで投稿リストを表示するときに
     // 数秒間古い投稿リストのデータが描画されてしまう
-    this.$store.commit("pagination/clear");
+    this.$store.commit("pagination/set", clearData);
     next();
   },
 };

--- a/frontend/src/views/ViewUserPage.vue
+++ b/frontend/src/views/ViewUserPage.vue
@@ -167,10 +167,7 @@ export default {
           .then((postResponse) => {
             if (postResponse.data.results.length) {
               // ページネーションの状態をセット
-              this.$store.commit(
-                "pagination/set",
-                postResponse.data
-              );
+              this.$store.commit("pagination/set", postResponse.data);
             } else {
               this.noPosts = "投稿はありません。";
             }
@@ -235,10 +232,21 @@ export default {
     }
   },
   beforeRouteLeave(to, from, next) {
+    // 初期化用データ
+    const clearData = {
+      next: "",
+      previous: "",
+      count: 0,
+      total_pages: 0,
+      current_page: 0,
+      page_size: 0,
+      results: [],
+    };
+
     // paginationの情報を初期化
     // この処理を行わないと別ページで投稿リストを表示するときに
     // 数秒間古い投稿リストのデータが描画されてしまう
-    this.$store.commit("pagination/clear");
+    this.$store.commit("pagination/set", clearData);
     next();
   },
 };


### PR DESCRIPTION
## Issue
#57 

## 内容
タイトルのページのbeforeRouteLeaveでのVuexの投稿リストデータ初期化処理で使用するMutationをclearからsetに変更