### PR TITLE
【MyPage.vue, HomePage.vue, ViewUserPage.vue】ページ遷移時のVuexの投稿リストを初期化する処理を修正

### DIFF
--- a/frontend/src/components/MyFavorites.vue
+++ b/frontend/src/components/MyFavorites.vue
@@ -27,9 +27,23 @@ export default {
     api.get("/favorite_posts/").then((response) => {
       // お気に入りの投稿が存在する場合
       if (response.data.results.length) {
+        // isMountedをtrueにする
+        this.$store.commit("pagination/changeIsMounted", true);
+
         this.favoritePostsList = response.data.results;
-        this.$store.dispatch("pagination/setPagination", response.data);
-      // お気に入りの投稿がない場合
+        this.$store
+          .dispatch("pagination/setPagination", response.data)
+          .then(() => {
+            // stateの変更が完了したらisMountedをfalseにする
+            this.$store.dispatch("pagination/setIsMounted", false);
+          })
+          .catch(() => {
+            // beforeRouteLeaveのwhileの処理が終わらないので
+            // stateの変更に失敗してもisMountedをfalseにする
+            this.$store.dispatch("pagination/setIsMounted", false);
+          });
+
+        // お気に入りの投稿がない場合
       } else {
         this.noFavorites = "お気に入りの投稿はありません。";
       }

--- a/frontend/src/store/modules/pagination.js
+++ b/frontend/src/store/modules/pagination.js
@@ -9,6 +9,7 @@ const state = {
 	searchKeyword: '', // 検索キーワード
 	searchCategorys: [], // カテゴリフィルタのリスト
 	searchPrefecture: '', // 都道府県フィルタの値
+	isMounted: false, // mountedで処理がsetが実行されている間はtrue
 };
 
 const getters = {
@@ -25,7 +26,8 @@ const getters = {
 	hasPrevious: state => !!state.previous, // 前のページがあるかどうか
 	searchKeyword: state => state.searchKeyword,
 	searchCategorys: state => state.searchCategorys,
-	searchPrefecture: state => state.searchPrefecture
+	searchPrefecture: state => state.searchPrefecture,
+	isMounted: state => state.isMounted,
 };
 
 const mutations = {
@@ -46,6 +48,10 @@ const mutations = {
 		state.currentPage = 0;
 		state.pageSize = 0;
 		state.results = [];
+	},
+	// isMountedの値を変更
+	changeIsMounted(state, boolean) {
+		state.isMounted = boolean;
 	},
 	setSearchKeyword(state, payload) {
 		state.searchKeyword = payload.searchKeyword;
@@ -91,6 +97,9 @@ const actions = {
 	},
 	destroySearchPrefecture({ commit }) {
 		commit('clearSearchPrefecture');
+	},
+	setIsMounted({ commit }, boolean) {
+		commit('changeIsMounted', boolean);
 	}
 };
 


### PR DESCRIPTION
## Issue
#57

## 内容
pagination.jsのstateにisMountedを追加
タイトルのページで投稿のリストのデータをpagination.jsのstateにセットしているときはisMountedをtrueに、セットが終わったらfalseにするという仕様に変更