### PR TITLE
【ユーザー表示モーダル画面】他のユーザーアカウントクリック時のバグを修正

### DIFF
--- a/frontend/src/components/TabMenu.vue
+++ b/frontend/src/components/TabMenu.vue
@@ -69,7 +69,7 @@ export default {
     option() {
       // ページ遷移しないタブ移動で親からもタブを移動させたいとき
       // propsのoptionからactiveの値を変換
-      if (this.option) {
+      if (this.option || this.option === 0) {
         this.active = this.option;
         this.$emit("resetOption");
       }

--- a/frontend/src/components/ViewFavoriteUsers.vue
+++ b/frontend/src/components/ViewFavoriteUsers.vue
@@ -65,6 +65,10 @@ export default {
         }
         // クリックされたユーザーが現在表示されているユーザーとは別のユーザーの場合
       } else if (this.username !== username) {
+        // モーダルを非表示
+        this.$emit("removeModalInViewFavoriteUsers");
+        // 同一ルート上でのparams変更
+        // 厳密には親コンポーネントのbeforeRouteUpdateで表示ユーザーを変更
         this.$router.push({ name: "viewUser", params: { username: username } });
         // クリックされたユーザーと現在表示されているユーザーが同じ場合
       } else {

--- a/frontend/src/components/ViewFollowers.vue
+++ b/frontend/src/components/ViewFollowers.vue
@@ -47,6 +47,10 @@ export default {
         }
         // クリックされたユーザーが現在表示されているユーザーとは別のユーザーの場合
       } else if (this.username !== username) {
+        // モーダルを非表示
+        this.$emit("removeModalInViewFollowers");
+        // 同一ルート上でのparams変更
+        // 厳密には親コンポーネントのbeforeRouteUpdateで表示ユーザーを変更
         this.$router.push({ name: "viewUser", params: { username: username } });
         // クリックされたユーザーと現在表示されているユーザーが同じ場合
       } else {


### PR DESCRIPTION
## Issue
#68 <br><br>

## 内容
- フォローしているユーザーやフォロワーを表示するモーダルで、他のユーザーのアカウントをクリックしたときにページの表示内容が切り替わらないバグを修正
- モーダルのコンポーネントにて、URLのparamsをクリックしたユーザーのユーザー名に切り替え、親コンポーネントであるViewUserPage.vueのbeforeRouteUpdateでURLの変更を検知して、表示しているユーザーのデータの再取得を行うようにコードを変更<br><br>