### PR TITLE
【投稿詳細画面】写真撮影地点の地図を表示できるように仕様を変更

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,5 +15,6 @@
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
+    <script async src="https://maps.googleapis.com/maps/api/js?key=AIzaSyApU8-UBtvd8OrCPUkIk4FGRrdulECIRDE"></script>
   </body>
 </html>

--- a/frontend/src/views/ViewPostPage.vue
+++ b/frontend/src/views/ViewPostPage.vue
@@ -124,6 +124,7 @@
           <h6 class="mb-2 title-h6">写真撮影場所</h6>
           <p>{{ post.zip_code }}</p>
           <p>{{ post.prefecture }}{{ post.location }}</p>
+          <div ref="map" class="map"></div>
         </div>
       </div>
     </div>
@@ -182,18 +183,33 @@ export default {
       },
     };
   },
-  mounted() {
+  async mounted() {
     // propsのIDから投稿の詳細なデータを取得
-    publicApi
-      .get("/posts/" + this.id + "/", {
-        params: {
-          retrieve: "True",
-        },
-      })
-      .then((response) => {
-        // dataに保存
-        this.post = response.data;
-      });
+    const { data } = await publicApi.get("/posts/" + this.id + "/", {
+      params: {
+        retrieve: "True",
+      },
+    });
+    this.post = data;
+    const address = this.post.prefecture + this.post.location;
+    let timer = setInterval(() => {
+      if (window.google) {
+        clearInterval(timer);
+        const geocoder = new window.google.maps.Geocoder();
+        geocoder.geocode({ address }, (results, status) => {
+          if (status === window.google.maps.GeocoderStatus.OK) {
+            const map = new window.google.maps.Map(this.$refs.map, {
+              center: results[0].geometry.location,
+              zoom: 17,
+            });
+            new window.google.maps.Marker({
+              position: results[0].geometry.location,
+              map,
+            });
+          }
+        });
+      }
+    }, 500);
   },
   methods: {
     // 投稿者のページへ移動
@@ -313,5 +329,18 @@ export default {
 }
 .border-bottom {
   border-bottom: 2px solid #eeeeee;
+}
+.map {
+  width: 400px;
+  height: 300px;
+  margin-top: 30px;
+  border: 2px solid gray;
+}
+
+@media screen and (max-width: 599px) {
+  .map {
+    width: 100%;
+    height: 250px;
+  }
 }
 </style>


### PR DESCRIPTION
## Issue
#74 

## 概要
写真撮影地点の所在地をもとにGoogleMapAPIから地図を取得し画面に表示した

以下詳細
- public/index.htmlにGoogleMapAPI（Maps JavaScript API）を読み込む処理を記述
- 投稿詳細画面に写真撮影地点の地図を表示

## 動作確認内容
質問詳細画面の画面下部に地図が表示されていることを確認