### PR TITLE
【投稿詳細画面】地図の仕様を変更

### DIFF
--- a/frontend/src/views/ViewPostPage.vue
+++ b/frontend/src/views/ViewPostPage.vue
@@ -124,7 +124,11 @@
           <h6 class="mb-2 title-h6">写真撮影場所</h6>
           <p>{{ post.zip_code }}</p>
           <p>{{ post.prefecture }}{{ post.location }}</p>
-          <div ref="map" class="map"></div>
+          <div
+            ref="map"
+            class="map"
+            v-if="post.prefecture && post.location"
+          ></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Issue
#76 

## 概要
投稿に所在地が設定されていない場合は地図を非表示にするよう仕様を変更した

## 動作確認概要
投稿詳細画面を開いて写真撮影地点の所在地が設定されていない投稿の場合地図の枠線が表示されないこと確認